### PR TITLE
Handle pool/connection-level errors on different drivers to prevent application from crashing out

### DIFF
--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -459,12 +459,12 @@ export class MysqlDriver implements Driver {
         return new Promise<any>((ok, fail) => {
             if (this.poolCluster) {
                 this.poolCluster.getConnection("MASTER", (err: any, dbConnection: any) => {
-                    err ? fail(err) : ok(dbConnection);
+                    err ? fail(err) : ok(this.prepareDbConnection(dbConnection));
                 });
 
             } else if (this.pool) {
                 this.pool.getConnection((err: any, dbConnection: any) => {
-                    err ? fail(err) : ok(dbConnection);
+                    err ? fail(err) : ok(this.prepareDbConnection(dbConnection));
                 });
             } else {
                 fail(new Error(`Connection is not established with mysql database`));
@@ -559,6 +559,15 @@ export class MysqlDriver implements Driver {
                 ok(pool);
             });
         });
+    }
+
+    /**
+     * Attaches all required base handlers to a database connection, such as the unhandled error handler.
+     */
+    private prepareDbConnection(connection: any): any {
+        const { logger } = this.connection;
+        connection.on("error", (error: any) => logger.log("warn", logger.log("warn", `MySQL connection raised an error. ${error}`)));
+        return connection;
     }
 
 }

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -566,7 +566,7 @@ export class MysqlDriver implements Driver {
      */
     private prepareDbConnection(connection: any): any {
         const { logger } = this.connection;
-        connection.on("error", (error: any) => logger.log("warn", logger.log("warn", `MySQL connection raised an error. ${error}`)));
+        connection.on("error", (error: any) => logger.log("warn", `MySQL connection raised an error. ${error}`));
         return connection;
     }
 

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -637,6 +637,8 @@ export class PostgresDriver implements Driver {
 
         // create a connection pool
         const pool = new this.postgres.Pool(connectionOptions);
+        const { logger } = this.connection;
+        pool.on("error", (error: any) => logger.log("warn", `Postgres pool raised an error. ${error}`));
 
         return new Promise((ok, fail) => {
             pool.connect((err: any, connection: any, release: Function) => {

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -577,7 +577,7 @@ export class SqlServerDriver implements Driver {
             const pool = new this.mssql.ConnectionPool(connectionOptions);
 
             const { logger } = this.connection;
-            pool.on("error", (error: any) => logger.log("warn", logger.log("warn", `MSSQL pool raised an error. ${error}`)));
+            pool.on("error", (error: any) => logger.log("warn", `MSSQL pool raised an error. ${error}`));
 
             const connection = pool.connect((err: any) => {
                 if (err) return fail(err);

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -574,7 +574,12 @@ export class SqlServerDriver implements Driver {
         // pooling is enabled either when its set explicitly to true,
         // either when its not defined at all (e.g. enabled by default)
         return new Promise<void>((ok, fail) => {
-            const connection = new this.mssql.ConnectionPool(connectionOptions).connect((err: any) => {
+            const pool = new this.mssql.ConnectionPool(connectionOptions);
+
+            const { logger } = this.connection;
+            pool.on("error", (error: any) => logger.log("warn", logger.log("warn", `MSSQL pool raised an error. ${error}`)));
+
+            const connection = pool.connect((err: any) => {
                 if (err) return fail(err);
                 ok(connection);
             });

--- a/test/github-issues/1689/issue-1689.ts
+++ b/test/github-issues/1689/issue-1689.ts
@@ -1,0 +1,1 @@
+// TODO pending pleerock's response to issue


### PR DESCRIPTION
Waiting on pleerock's response on how to write a test for this. I've tested this manually locally by building and copying the package over the ftr-api one.