### PR TITLE
Use tablepath when deleting rows

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -340,7 +340,7 @@ export class Gulpfile {
         chai.use(require("sinon-chai"));
         chai.use(require("chai-as-promised"));
 
-        return gulp.src(["./build/compiled/test/**/*.js"])
+        return gulp.src(["./build/compiled/test/**/delete-orphans.js"])
             .pipe(mocha({
                 bail: true,
                 grep: !!args.grep ? new RegExp(args.grep) : undefined,

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -340,7 +340,7 @@ export class Gulpfile {
         chai.use(require("sinon-chai"));
         chai.use(require("chai-as-promised"));
 
-        return gulp.src(["./build/compiled/test/**/delete-orphans.js"])
+        return gulp.src(["./build/compiled/test/**/*.js"])
             .pipe(mocha({
                 bail: true,
                 grep: !!args.grep ? new RegExp(args.grep) : undefined,

--- a/src/persistence/SubjectOperationExecutor.ts
+++ b/src/persistence/SubjectOperationExecutor.ts
@@ -830,15 +830,15 @@ export class SubjectOperationExecutor {
             subject.metadata.primaryColumns.forEach(column => {
                 parentConditions[column.databaseName] = column.getEntityValue(subject.databaseEntity);
             });
-            await this.queryRunner.delete(subject.metadata.parentEntityMetadata.tableName, parentConditions);
+            await this.queryRunner.delete(subject.metadata.parentEntityMetadata.tablePath, parentConditions);
 
             const childConditions: ObjectLiteral = {};
             subject.metadata.primaryColumns.forEach(column => {
                 childConditions[column.databaseName] = column.getEntityValue(subject.databaseEntity);
             });
-            await this.queryRunner.delete(subject.metadata.tableName, childConditions);
+            await this.queryRunner.delete(subject.metadata.tablePath, childConditions);
         } else {
-            await this.queryRunner.delete(subject.metadata.tableName, subject.metadata.getDatabaseEntityIdMap(subject.databaseEntity)!);
+            await this.queryRunner.delete(subject.metadata.tablePath, subject.metadata.getDatabaseEntityIdMap(subject.databaseEntity)!);
         }
     }
 

--- a/test/functional/persistence/delete-orphans/entity/Category.ts
+++ b/test/functional/persistence/delete-orphans/entity/Category.ts
@@ -3,7 +3,7 @@ import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/Prima
 import {Post} from "./Post";
 import {OneToMany} from "../../../../../src/decorator/relations/OneToMany";
 
-@Entity()
+@Entity("category", { schema: "something" })
 export class Category {
 
     @PrimaryGeneratedColumn()

--- a/test/functional/persistence/delete-orphans/entity/Post.ts
+++ b/test/functional/persistence/delete-orphans/entity/Post.ts
@@ -6,7 +6,7 @@ import {ManyToOne} from "../../../../../src/decorator/relations/ManyToOne";
 import {JoinColumn} from "../../../../../src/decorator/relations/JoinColumn";
 import { OrphanedRowAction } from "../../../../../src/decorator/options/OrphanedRowAction";
 
-@Entity()
+@Entity("post", { schema: "something" })
 export class Post {
 
     @PrimaryGeneratedColumn()


### PR DESCRIPTION
Ran into an issue when removing (deleting) entities that were held in a table schema different from 'public', where the schema name wouldn't be used in the DELETE operation.

This is a bugfix for the following situation:

eg: 
```typescript
@Entity('transcript', { schema: 'transcript'})
class Transcript {}

await transcriptRepository.deleteById(...)
```

Actual:
`DELETE from transcript where id = ...`
Expected:
`DELETE from transcript.transcript where id = ...`