### PR TITLE
FTRX-5000 Fix many to many delete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.1.12",
+  "version": "0.1.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typeorm",
   "private": true,
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Data-Mapper ORM for TypeScript, ES7, ES6, ES5. Supports MySQL, PostgreSQL, MariaDB, SQLite, MS SQL Server, Oracle, WebSQL, MongoDB databases.",
   "license": "MIT",
   "readmeFilename": "README.md",

--- a/src/persistence/SubjectOperationExecutor.ts
+++ b/src/persistence/SubjectOperationExecutor.ts
@@ -943,7 +943,10 @@ export class SubjectOperationExecutor {
             secondJoinColumns.forEach(joinColumn => {
                 inverseConditions[joinColumn.databaseName] = joinColumn.referencedColumn!.getEntityValue(relationIds);
             });
-            return this.queryRunner.delete(junctionMetadata.tableName, Object.assign({}, inverseConditions, conditions));
+            const tablePath = junctionMetadata.schema
+                ? `${junctionMetadata.schema}.${junctionMetadata.tableName}`
+                : junctionMetadata.tableName;
+            return this.queryRunner.delete(tablePath, Object.assign({}, inverseConditions, conditions));
         });
 
         await Promise.all(removePromises);


### PR DESCRIPTION
Our many-to-many delete does not recognise the schema attribute in `@ManyToMany` metadata.

This results in "relation doesn't exist" errors when trying to clear many to many relations on an entity.