### PR TITLE
FTRX-5492 Update the deep partial type to work with typescript 3.6, b…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ftr/typeorm",
   "private": true,
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Data-Mapper ORM for TypeScript, ES7, ES6, ES5. Supports MySQL, PostgreSQL, MariaDB, SQLite, MS SQL Server, Oracle, WebSQL, MongoDB databases.",
   "license": "MIT",
   "readmeFilename": "README.md",

--- a/src/common/DeepPartial.ts
+++ b/src/common/DeepPartial.ts
@@ -1,6 +1,9 @@
 /**
  * Same as Partial<T> but goes deeper and makes Partial<T> all its properties and sub-properties.
+ * Implemented in FTRX-5492 to support upgrading typescript to 3.6.
+ * This is not the latest version of the code provided by typeorm, but it fixes beast.
+ * @see https://github.com/Microsoft/TypeScript/issues/21592#issuecomment-496723647
  */
 export type DeepPartial<T> = {
-    [P in keyof T]?: DeepPartial<T[P]>;
+    [P in keyof T]?: T[P] extends never ? DeepPartial<T[P]> : DeepPartial<T[P]>
 };


### PR DESCRIPTION
…ecause typescript haven't released a fix yet

Fixes typeorm so we can upgrade typescript in beast to 3.6
Without this, we see:
error TS2321: Excessive stack depth comparing types 'any' and 'DeepPartial<TWriteModel> | undefined'.
