### PR TITLE
Allow passing through prototypes to skip merge deep for

### DIFF
--- a/src/connection/BaseConnectionOptions.ts
+++ b/src/connection/BaseConnectionOptions.ts
@@ -6,10 +6,13 @@ import {Logger} from "../logger/Logger";
 import {Connection} from "./Connection";
 import {QueryResultCache} from "../cache/QueryResultCache";
 
+export type Constructor = new (...args: any[]) => Object;
+
 /**
  * BaseConnectionOptions is set of connection options shared by all database types.
  */
 export interface BaseConnectionOptions {
+    readonly skipMergeDeepPrototypes?: Constructor[];
 
     /**
      * Database type. This value is required.

--- a/src/driver/aurora-data-api/AuroraDataApiDriver.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiDriver.ts
@@ -695,7 +695,7 @@ export class AuroraDataApiDriver implements Driver {
             //     value = generatedColumn.getEntityValue(uuidMap);
             }
 
-            return OrmUtils.mergeDeep(map, generatedColumn.createValueMap(value));
+            return OrmUtils.mergeDeep(this.connection.options.skipMergeDeepPrototypes, map, generatedColumn.createValueMap(value));
         }, {} as ObjectLiteral);
 
         return Object.keys(generatedMap).length > 0 ? generatedMap : undefined;

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -585,7 +585,7 @@ export class CockroachDriver implements Driver {
         return Object.keys(insertResult).reduce((map, key) => {
             const column = metadata.findColumnWithDatabaseName(key);
             if (column) {
-                OrmUtils.mergeDeep(map, column.createValueMap(this.prepareHydratedValue(insertResult[key], column)));
+                OrmUtils.mergeDeep(this.connection.options.skipMergeDeepPrototypes, map, column.createValueMap(this.prepareHydratedValue(insertResult[key], column)));
             }
             return map;
         }, {} as ObjectLiteral);

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -721,7 +721,7 @@ export class MysqlDriver implements Driver {
             //     value = generatedColumn.getEntityValue(uuidMap);
             }
 
-            return OrmUtils.mergeDeep(map, generatedColumn.createValueMap(value));
+            return OrmUtils.mergeDeep(this.connection.options.skipMergeDeepPrototypes, map, generatedColumn.createValueMap(value));
         }, {} as ObjectLiteral);
 
         return Object.keys(generatedMap).length > 0 ? generatedMap : undefined;

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -586,7 +586,7 @@ export class OracleDriver implements Driver {
         return Object.keys(insertResult).reduce((map, key) => {
             const column = metadata.findColumnWithDatabaseName(key);
             if (column) {
-                OrmUtils.mergeDeep(map, column.createValueMap(this.prepareHydratedValue(insertResult[key], column)));
+                OrmUtils.mergeDeep(this.connection.options.skipMergeDeepPrototypes, map, column.createValueMap(this.prepareHydratedValue(insertResult[key], column)));
             }
             return map;
         }, {} as ObjectLiteral);

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -877,7 +877,7 @@ export class PostgresDriver implements Driver {
         return Object.keys(insertResult).reduce((map, key) => {
             const column = metadata.findColumnWithDatabaseName(key);
             if (column) {
-                OrmUtils.mergeDeep(map, column.createValueMap(insertResult[key]));
+                OrmUtils.mergeDeep(this.connection.options.skipMergeDeepPrototypes, map, column.createValueMap(insertResult[key]));
                 // OrmUtils.mergeDeep(map, column.createValueMap(this.prepareHydratedValue(insertResult[key], column))); // TODO: probably should be like there, but fails on enums, fix later
             }
             return map;

--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -563,7 +563,7 @@ export class SapDriver implements Driver {
                 //     value = generatedColumn.getEntityValue(uuidMap);
             }
 
-            return OrmUtils.mergeDeep(map, generatedColumn.createValueMap(value));
+            return OrmUtils.mergeDeep(this.connection.options.skipMergeDeepPrototypes, map, generatedColumn.createValueMap(value));
         }, {} as ObjectLiteral);
 
         return Object.keys(generatedMap).length > 0 ? generatedMap : undefined;

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -542,7 +542,7 @@ export abstract class AbstractSqliteDriver implements Driver {
             }
 
             if (!value) return map;
-            return OrmUtils.mergeDeep(map, generatedColumn.createValueMap(value));
+            return OrmUtils.mergeDeep(this.connection.options.skipMergeDeepPrototypes, map, generatedColumn.createValueMap(value));
         }, {} as ObjectLiteral);
 
         return Object.keys(generatedMap).length > 0 ? generatedMap : undefined;

--- a/src/driver/sqljs/SqljsDriver.ts
+++ b/src/driver/sqljs/SqljsDriver.ts
@@ -213,7 +213,7 @@ export class SqljsDriver extends AbstractSqliteDriver {
                 try {
                     let result = this.databaseConnection.exec(query);
                     this.connection.logger.logQuery(query);
-                    return OrmUtils.mergeDeep(map, generatedColumn.createValueMap(result[0].values[0][0]));
+                    return OrmUtils.mergeDeep(this.connection.options.skipMergeDeepPrototypes, map, generatedColumn.createValueMap(result[0].values[0][0]));
                 }
                 catch (e) {
                     this.connection.logger.logQueryError(e, query, []);

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -590,7 +590,7 @@ export class SqlServerDriver implements Driver {
         return Object.keys(insertResult).reduce((map, key) => {
             const column = metadata.findColumnWithDatabaseName(key);
             if (column) {
-                OrmUtils.mergeDeep(map, column.createValueMap(this.prepareHydratedValue(insertResult[key], column)));
+                OrmUtils.mergeDeep(this.connection.options.skipMergeDeepPrototypes, map, column.createValueMap(this.prepareHydratedValue(insertResult[key], column)));
             }
             return map;
         }, {} as ObjectLiteral);

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -558,7 +558,7 @@ export class ColumnMetadata {
                 const map = this.relationMetadata.joinColumns.reduce((map, joinColumn) => {
                     const value = joinColumn.referencedColumn!.getEntityValueMap(entity[this.relationMetadata!.propertyName]);
                     if (value === undefined) return map;
-                    return OrmUtils.mergeDeep(map, value);
+                    return OrmUtils.mergeDeep(this.entityMetadata.connection.options.skipMergeDeepPrototypes, map, value);
                 }, {});
                 if (Object.keys(map).length > 0)
                     return { [this.propertyName]: map };

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -590,7 +590,7 @@ export class EntityMetadata {
         if (!entity)
             return undefined;
 
-        return EntityMetadata.getValueMap(entity, this.primaryColumns, { skipNulls: true });
+        return this.getValueMap(entity, this.primaryColumns, { skipNulls: true });
     }
 
     /**
@@ -762,7 +762,7 @@ export class EntityMetadata {
      * Creates value map from the given values and columns.
      * Examples of usages are primary columns map and join columns map.
      */
-    static getValueMap(entity: ObjectLiteral, columns: ColumnMetadata[], options?: { skipNulls?: boolean }): ObjectLiteral|undefined {
+    getValueMap(entity: ObjectLiteral, columns: ColumnMetadata[], options?: { skipNulls?: boolean }): ObjectLiteral|undefined {
         return columns.reduce((map, column) => {
             const value = column.getEntityValueMap(entity, options);
 
@@ -770,7 +770,7 @@ export class EntityMetadata {
             if (map === undefined || value === null || value === undefined)
                 return undefined;
 
-            return column.isObjectId ? Object.assign(map, value) : OrmUtils.mergeDeep(map, value);
+            return column.isObjectId ? Object.assign(map, value) : OrmUtils.mergeDeep(this.connection.options.skipMergeDeepPrototypes, map, value);
         }, {} as ObjectLiteral|undefined);
     }
 
@@ -846,8 +846,8 @@ export class EntityMetadata {
      */
     createPropertiesMap(): { [name: string]: string|any } {
         const map: { [name: string]: string|any } = {};
-        this.columns.forEach(column => OrmUtils.mergeDeep(map, column.createValueMap(column.propertyPath)));
-        this.relations.forEach(relation => OrmUtils.mergeDeep(map, relation.createValueMap(relation.propertyPath)));
+        this.columns.forEach(column => OrmUtils.mergeDeep(this.connection.options.skipMergeDeepPrototypes, map, column.createValueMap(column.propertyPath)));
+        this.relations.forEach(relation => OrmUtils.mergeDeep(this.connection.options.skipMergeDeepPrototypes, map, relation.createValueMap(relation.propertyPath)));
         return map;
     }
 

--- a/src/metadata/RelationMetadata.ts
+++ b/src/metadata/RelationMetadata.ts
@@ -336,7 +336,7 @@ export class RelationMetadata {
         const referencedColumns = joinColumns.map(joinColumn => joinColumn.referencedColumn!);
         // console.log("entity", entity);
         // console.log("referencedColumns", referencedColumns);
-        return EntityMetadata.getValueMap(entity, referencedColumns);
+        return this.entityMetadata.getValueMap(entity, referencedColumns);
     }
 
     /**

--- a/src/persistence/Subject.ts
+++ b/src/persistence/Subject.ts
@@ -272,7 +272,7 @@ export class Subject {
                 }
             }
 
-            OrmUtils.mergeDeep(updateMap, valueMap);
+            OrmUtils.mergeDeep(this.metadata.connection.options.skipMergeDeepPrototypes, updateMap, valueMap);
             return updateMap;
         }, {} as ObjectLiteral);
         this.changeMaps = changeMapsWithoutValues;

--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -387,7 +387,7 @@ export class SubjectExecutor {
 
             // for mongodb we have a bit different updation logic
             if (this.queryRunner instanceof MongoQueryRunner) {
-                const partialEntity = OrmUtils.mergeDeep({}, subject.entity!);
+                const partialEntity = OrmUtils.mergeDeep(this.queryRunner.connection.options.skipMergeDeepPrototypes, {}, subject.entity!);
                 if (subject.metadata.objectIdColumn && subject.metadata.objectIdColumn.propertyName) {
                     delete partialEntity[subject.metadata.objectIdColumn.propertyName];
                 }
@@ -551,7 +551,7 @@ export class SubjectExecutor {
 
             // for mongodb we have a bit different updation logic
             if (this.queryRunner instanceof MongoQueryRunner) {
-                const partialEntity = OrmUtils.mergeDeep({}, subject.entity!);
+                const partialEntity = OrmUtils.mergeDeep(this.queryRunner.connection.options.skipMergeDeepPrototypes, {}, subject.entity!);
                 if (subject.metadata.objectIdColumn && subject.metadata.objectIdColumn.propertyName) {
                     delete partialEntity[subject.metadata.objectIdColumn.propertyName];
                 }
@@ -631,7 +631,7 @@ export class SubjectExecutor {
 
             // for mongodb we have a bit different updation logic
             if (this.queryRunner instanceof MongoQueryRunner) {
-                const partialEntity = OrmUtils.mergeDeep({}, subject.entity!);
+                const partialEntity = OrmUtils.mergeDeep(this.queryRunner.connection.options.skipMergeDeepPrototypes, {}, subject.entity!);
                 if (subject.metadata.objectIdColumn && subject.metadata.objectIdColumn.propertyName) {
                     delete partialEntity[subject.metadata.objectIdColumn.propertyName];
                 }

--- a/src/persistence/subject-builder/ManyToManySubjectBuilder.ts
+++ b/src/persistence/subject-builder/ManyToManySubjectBuilder.ts
@@ -232,10 +232,10 @@ export class ManyToManySubjectBuilder {
 
         const identifier: ObjectLiteral = {};
         relation.junctionEntityMetadata!.ownerColumns.forEach(column => {
-            OrmUtils.mergeDeep(identifier, column.createValueMap(column.referencedColumn!.getEntityValue(ownerEntityMap)));
+            OrmUtils.mergeDeep(subject.metadata.connection.options.skipMergeDeepPrototypes, identifier, column.createValueMap(column.referencedColumn!.getEntityValue(ownerEntityMap)));
         });
         relation.junctionEntityMetadata!.inverseColumns.forEach(column => {
-            OrmUtils.mergeDeep(identifier, column.createValueMap(column.referencedColumn!.getEntityValue(inverseEntityMap)));
+            OrmUtils.mergeDeep(subject.metadata.connection.options.skipMergeDeepPrototypes, column.createValueMap(column.referencedColumn!.getEntityValue(inverseEntityMap)));
         });
         return identifier;
     }

--- a/src/persistence/tree/NestedSetSubjectExecutor.ts
+++ b/src/persistence/tree/NestedSetSubjectExecutor.ts
@@ -62,18 +62,20 @@ export class NestedSetSubjectExecutor {
                 `WHERE ${rightColumnName} >= ${parentNsRight}`);
 
             OrmUtils.mergeDeep(
+                this.queryRunner.connection.options.skipMergeDeepPrototypes,
                 subject.insertedValueSet,
                 subject.metadata.nestedSetLeftColumn!.createValueMap(parentNsRight),
                 subject.metadata.nestedSetRightColumn!.createValueMap(parentNsRight + 1),
             );
         } else {
             const isUniqueRoot = await this.isUniqueRootEntity(subject, parent);
-            
+
             // Validate if a root entity already exits and throw an exception
             if (!isUniqueRoot)
                 throw new NestedSetMultipleRootError();
 
             OrmUtils.mergeDeep(
+                this.queryRunner.connection.options.skipMergeDeepPrototypes,
                 subject.insertedValueSet,
                 subject.metadata.nestedSetLeftColumn!.createValueMap(1),
                 subject.metadata.nestedSetRightColumn!.createValueMap(2),
@@ -138,18 +140,18 @@ export class NestedSetSubjectExecutor {
                 } else {
                     entitySize = parentNs.right - entityNs.left;
                 }
-                
+
                 // Moved entity logic
-                const updateLeftSide = 
+                const updateLeftSide =
                     `WHEN ${leftColumnName} >= ${entityNs.left} AND ` +
                         `${leftColumnName} < ${entityNs.right} ` +
                     `THEN ${leftColumnName} + ${entitySize} `;
 
-                const updateRightSide = 
+                const updateRightSide =
                     `WHEN ${rightColumnName} > ${entityNs.left} AND ` +
                         `${rightColumnName} <= ${entityNs.right} ` +
                     `THEN ${rightColumnName} + ${entitySize} `;
-                
+
                 // Update the surrounding entities
                 if (isMovingUp) {
                     await this.queryRunner.query(`UPDATE ${tableName} ` +
@@ -187,7 +189,7 @@ export class NestedSetSubjectExecutor {
             }
         } else {
             const isUniqueRoot = await this.isUniqueRootEntity(subject, parent);
-            
+
             // Validate if a root entity already exits and throw an exception
             if (!isUniqueRoot)
                 throw new NestedSetMultipleRootError();
@@ -211,7 +213,7 @@ export class NestedSetSubjectExecutor {
         let entitiesIds: ObjectLiteral[] = [];
         for (const subject of subjects) {
             const entityId = metadata.getEntityIdMap(subject.entity);
-            
+
             if (entityId) {
                 entitiesIds.push(entityId);
             }
@@ -267,7 +269,7 @@ export class NestedSetSubjectExecutor {
                     }
                     data.push(entry);
                 }
-                
+
                 return data;
             });
     }

--- a/src/query-builder/ReturningResultsEntityUpdator.ts
+++ b/src/query-builder/ReturningResultsEntityUpdator.ts
@@ -105,7 +105,7 @@ export class ReturningResultsEntityUpdator {
                         if (!uuid) // if it was not defined by a user then InsertQueryBuilder generates it by its own, get this generated uuid value
                             uuid = this.expressionMap.nativeParameters["uuid_" + generatedColumn.databaseName + entityIndex];
 
-                        OrmUtils.mergeDeep(generatedMap, generatedColumn.createValueMap(uuid));
+                        OrmUtils.mergeDeep(this.queryRunner.connection.options.skipMergeDeepPrototypes, generatedMap, generatedColumn.createValueMap(uuid));
                     }
                 });
             }

--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -247,12 +247,12 @@ export class RawSqlResultsToEntityTransformer {
                         if (column.isVirtual && column.referencedColumn && column.referencedColumn.propertyName !== column.propertyName) // if column is a relation
                             value = column.referencedColumn.createValueMap(value);
 
-                        return OrmUtils.mergeDeep(idMap, column.createValueMap(value));
+                        return OrmUtils.mergeDeep(this.driver.options.skipMergeDeepPrototypes, idMap, column.createValueMap(value));
                     } else {
                         if (column.referencedColumn!.referencedColumn) // if column is a relation
                             value = column.referencedColumn!.referencedColumn!.createValueMap(value);
 
-                        return OrmUtils.mergeDeep(idMap, column.referencedColumn!.createValueMap(value));
+                        return OrmUtils.mergeDeep(this.driver.options.skipMergeDeepPrototypes, idMap, column.referencedColumn!.createValueMap(value));
                     }
                 }, {} as ObjectLiteral);
 

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -1,4 +1,5 @@
 import {ObjectLiteral} from "../common/ObjectLiteral";
+import { Constructor } from "../connection/BaseConnectionOptions";
 
 export class OrmUtils {
 
@@ -67,7 +68,7 @@ export class OrmUtils {
      *
      * @see http://stackoverflow.com/a/34749873
      */
-    static mergeDeep(target: any, ...sources: any[]): any {
+    static mergeDeep(skipMergeDeepPrototypes: Constructor[] = [],target: any, ...sources: any[]): any {
         if (!sources.length) return target;
         const source = sources.shift();
 
@@ -82,17 +83,18 @@ export class OrmUtils {
                 && !(value instanceof Set)
                 && !(value instanceof Date)
                 && !(value instanceof Buffer)
-                && !(value instanceof RegExp)) {
+                && !(value instanceof RegExp)
+                && skipMergeDeepPrototypes.every(X => !(value instanceof X))) {
                     if (!target[key])
                         Object.assign(target, { [key]: Object.create(Object.getPrototypeOf(value)) });
-                    this.mergeDeep(target[key], value);
+                    this.mergeDeep(skipMergeDeepPrototypes, target[key], value);
                 } else {
                     Object.assign(target, { [key]: value });
                 }
             }
         }
 
-        return this.mergeDeep(target, ...sources);
+        return this.mergeDeep(skipMergeDeepPrototypes, target, ...sources);
     }
 
     /**


### PR DESCRIPTION
Yet to create a PR in TypeORM for this one.

Question: Constructor or Prototype?

A part of me is not super happy with this code and I'd love to clean it up somehow. It's just a bit hard because the only configuration point is at the connection level and the problematic code is in a static method so we have to just pass in the parameter for the state. I also had to make it the first parameter because of the use of the rest operator on the last parameter (...sources: any[]).

I was thinking that maybe a nicer and more flexible approach could be to instead of passing in a list of constructors/prototypes, we could pass in a list of a predicate and a mergeDeep. Interested in your thoughts.

It also doesn't have tests which I'd need to add for the TypeORM PR. Do we want it for our own repo too? Maybe we might as well?