### PR TITLE
Hardcode the skip merge on `ZoneOffset`

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -82,7 +82,8 @@ export class OrmUtils {
                 && !(value instanceof Set)
                 && !(value instanceof Date)
                 && !(value instanceof Buffer)
-                && !(value instanceof RegExp)) {
+                && !(value instanceof RegExp)
+                && !(value.constructor.name === "ZoneOffset")) {
                     if (!target[key])
                         Object.assign(target, { [key]: Object.create(Object.getPrototypeOf(value)) });
                     this.mergeDeep(target[key], value);


### PR DESCRIPTION
This is an alternative to [this PR](https://github.com/FTRLabs/typeorm/pull/11) as suggested by @danewilson [here](https://github.com/FTRLabs/typeorm/pull/11#issuecomment-862802630).

I think this is a brilliant idea as it is a smaller change which, for the purposes of this fork, will allow us to stay on the mainline more easily.

I still plan on opening on PR into the mainline with the less hacky solution.