### PR TITLE
Remove the instruction to cd into build/package as it's in the publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Run:
 ```
 npm version prerelease
 npm run package
-cd build/package
 npm publish --tag FTRX-5000 build/package # Replace 5000 with your issue number
 ```
 
@@ -30,7 +29,6 @@ To publish the project, compile and package the project first. This can be achie
 ```
 npm version patch # Replace patch with major/minor as appropriate
 npm run package
-cd build/package
 npm publish build/package
 ```
 


### PR DESCRIPTION
Very minor - I just didn't see it in the publish command.