### PR TITLE
Turn mainline into our fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,41 @@
+# FTR README
+
+## Development and testing
+
+Please see the [developer guide](DEVELOPER.md) if you are interested.
+
+At the time of writing, it's too much work for a simple fix.
+
+## Publishing
+
+Prior to publication, follow FTR's [Working with npm packages in feature branches][npm-doc] guide to create a feature branch then test it with dependent projects such as `ftr-beast`.
+
+Summary is below:
+
+### Pre-release
+
+Run:
+
+```
+npm version prerelease
+npm run package
+npm publish --tag FTRX-5000 build/package # Replace 5000 with your issue number
+```
+
+### Actual release
+
+To publish the project, compile and package the project first. This can be achieved by the command:
+
+```
+npm version patch # Replace patch with major/minor as appropriate
+npm run package
+npm publish build/package
+```
+
+[npm-doc]: https://fortherecord.atlassian.net/wiki/spaces/FPX/pages/150470657/Working+with+npm+packages+in+feature+branches
+
+# Original README
+
 <div align="center">
   <a href="http://typeorm.io/">
     <img src="https://github.com/typeorm/typeorm/raw/master/resources/logo_big.png" width="492" height="228">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "typeorm",
+  "name": "@ftr/typeorm",
   "version": "0.2.34",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typeorm",
+  "name": "@ftr/typeorm",
   "private": true,
   "version": "0.2.34",
   "description": "Data-Mapper ORM for TypeScript, ES7, ES6, ES5. Supports MySQL, PostgreSQL, MariaDB, SQLite, MS SQL Server, Oracle, MongoDB databases.",

--- a/src/commands/MigrationCreateCommand.ts
+++ b/src/commands/MigrationCreateCommand.ts
@@ -90,7 +90,7 @@ export class MigrationCreateCommand implements yargs.CommandModule {
      * Gets contents of the migration file.
      */
     protected static getTemplate(name: string, timestamp: number): string {
-        return `import {MigrationInterface, QueryRunner} from "typeorm";
+        return `import {MigrationInterface, QueryRunner} from "@ftr/typeorm";
 
 export class ${camelCase(name, true)}${timestamp} implements MigrationInterface {
 


### PR DESCRIPTION
These are the 3 commits to turn the mainline into our fork:
1. Update the README
2. Rename the package
3. Update migration template to reference our fork